### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Open an issue before large changes; pref
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tryonlabs/opentryon&type=date&legend=top-left)](https://www.star-history.com/#tryonlabs/opentryon&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tryonlabs/opentryon&type=date&legend=top-left)](https://star-history.dera.page/#tryonlabs/opentryon&type=date&legend=top-left)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is currently broken and renders empty because the upstream star-history.com endpoint no longer works under GitHub's stargazer API restrictions. Point the chart at a working mirror of the same service so the history renders again.