### PR TITLE
Document MCP and TryOn Studio on the docs site

### DIFF
--- a/.cursor/skills/deploy-docs/SKILL.md
+++ b/.cursor/skills/deploy-docs/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: deploy-docs
+description: >-
+  Builds the OpenTryOn Docusaurus site in docs/, commits and pushes to the docs
+  branch, and deploys GitHub Pages (gh-pages). Use when the user asks to build
+  docs, deploy documentation, publish GitHub Pages, npm run deploy, or run
+  /deploy-docs. Commit the code to the docs branch and do not commit to the main
+  branch. This skill will not create a pull request to merge the doc branch to
+  the main branch.
+---
+
+# Deploy docs (GitHub Pages)
+
+Publish the Docusaurus site from `docs/` to **https://tryonlabs.github.io/opentryon/**.
+
+GitHub Pages is served from the **`gh-pages`** branch (`docs/package.json` `npm run deploy` → `docusaurus build && gh-pages -d build`). The Actions workflow `.github/workflows/deploy-docs.yml` is disabled.
+
+Commit the code to the docs branch and do not commit to the main branch. This skill will not create a pull request to merge the doc branch to the main branch.
+
+Repo root: OpenTryOn (`opentryon/`). In a multi-root workspace, run every command with `working_directory` `/Users/apple/tryonlabs/repos/opentryon` (or `git -C` that path).
+
+## Constraints (do not skip)
+
+| Allowed | Forbidden |
+|---|---|
+| Commit **only** on **`docs`** | Commit on `main`, `master`, or any other branch |
+| Push **`docs`** (source) and **`gh-pages`** (Pages, via `gh-pages` CLI) | Push `main` / `master` |
+| `npm run build` then `npx gh-pages -d build` | `gh pr create`, `gh pr edit`, any PR from `docs` → `main` |
+| | Force-push unless the user explicitly asked **and** the target is not `main`/`master` |
+| | Amend, skip hooks, edit `git config` |
+
+`gh-pages -d build` creates a commit **on `gh-pages` only**. That is the Pages deploy, not a source commit on `main`.
+
+## Workflow
+
+```
+Task Progress:
+- [ ] 1. Confirm repo + move work onto docs (never commit on main)
+- [ ] 2. Install + build docs/
+- [ ] 3. Commit on docs (if there is something to commit)
+- [ ] 4. Push origin docs
+- [ ] 5. Deploy to gh-pages
+- [ ] 6. Return URLs — no PR
+```
+
+### 1. Confirm repo + land on `docs`
+
+```bash
+git rev-parse --show-toplevel
+git rev-parse --abbrev-ref HEAD
+git status -sb
+```
+
+**Stop if** the toplevel is not the `opentryon` repo.
+
+If HEAD is `main` or `master`: **do not commit**. Switch to `docs` first, bringing uncommitted work along:
+
+```bash
+git stash push -u -m "deploy-docs"
+git checkout docs 2>/dev/null || git checkout -b docs
+git stash pop
+```
+
+If `docs` does not exist locally but exists on origin: `git checkout -b docs origin/docs` (then stash pop).
+
+If HEAD is already `docs`, continue.
+
+If HEAD is some other feature branch: stop and say the skill only commits on `docs` — do not commit that feature branch and do not commit `main`.
+
+### 2. Build
+
+From `docs/` (Node ≥ 18):
+
+```bash
+npm install
+npm run build
+```
+
+`onBrokenLinks` is `throw`. If the build fails, fix the reported links (or stop and report). Do not deploy a failed build.
+
+Built files: `docs/build/`. Site path: `baseUrl` `/opentryon/`. Do not commit `docs/build/` or `docs/node_modules/` (they are gitignored).
+
+### 3. Commit on `docs` only
+
+Confirm `git rev-parse --abbrev-ref HEAD` is `docs`. If it is `main`/`master`, go back to step 1 — never `git commit` there.
+
+Then, in parallel:
+
+```bash
+git status
+git diff
+git log -5 --oneline
+```
+
+Stage documentation and skill files that belong in this deploy (typically `docs/`, `README.md`, `mcp-server/README.md`, `.cursor/skills/deploy-docs/` as relevant). Do **not** stage secrets (`.env`, credentials).
+
+If there is nothing to commit, skip to step 4.
+
+Commit with a HEREDOC (no `-i`, no `--amend`, no `--no-verify`):
+
+```bash
+git commit -m "$(cat <<'EOF'
+Short why-focused message for the docs update.
+
+EOF
+)"
+```
+
+### 4. Push `docs`
+
+```bash
+git push -u origin docs
+```
+
+Needs network (`required_permissions: ["all"]`). Do **not** push `main`.
+
+### 5. Deploy (push `gh-pages` only)
+
+From `docs/`:
+
+```bash
+npx gh-pages -d build
+```
+
+(`npm run deploy` rebuilds then runs `gh-pages -d build`. Prefer `npx gh-pages -d build` after a successful step 2.)
+
+### 6. Reply
+
+Return:
+
+1. Build result (ok / failed)
+2. Commit on **`docs`** (hash / that there was nothing to commit)
+3. That **`docs`** was pushed
+4. That **`gh-pages`** was updated (or the error)
+5. That **no PR** was opened to merge `docs` into `main`
+6. Live URL: https://tryonlabs.github.io/opentryon/ (allow a few minutes for Pages)
+
+## Do not
+
+- Commit the code to the main branch
+- Create a pull request to merge the docs branch to the main branch
+- Push `main` / `master`
+- Force-push `main` / `master`
+- Edit `git config`
+- Treat Actions `deploy-docs.yml` as the deploy path
+- Put secrets in the reply

--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ API tutorials, configuration, examples, and agent guides live there — not in t
 | **Video** | Veo, Sora, Luma Ray 2 + Ray 3.2, Seedance 2.5, Kling 3.0 / Omni / Turbo, Grok Imagine Video 1.5, Gemini Omni Flash, Pruna P-Video / Replace / Avatar / Animate, **LTX-2.5** (API + local), **Hailuo 2.3**, **MiniMax H3** (API + local), **Wan** (API + local 2.2), **Runway Gen-4.5** |
 | **Other** | BEN2 background removal, garment/human preprocessing, fashion datasets, planner agent (registry `invoke_model`) |
 
-## Three ways to use it
+## Four ways to use it
 
 1. **CLI** — `opentryon <service> --model <model> [params...]`
-2. **MCP server** — expose every registry model as tools for Claude, Cursor, or [tryon-studio](https://github.com/tryonlabs/tryon-studio)
-3. **Python** — `from tryon.api import ...` (and `tryon.cli.runner.invoke_model`)
-
-The unified Next.js + Tailwind web UI is **not** in this repo — it lives in [`tryon-studio`](https://github.com/tryonlabs/tryon-studio) and talks to OpenTryOn over MCP.
+2. **MCP server** — expose every registry model as tools for Claude, Cursor, or [TryOn Studio](https://tryonlabs.github.io/opentryon/getting-started/tryon-studio). Guide: [MCP Server](https://tryonlabs.github.io/opentryon/getting-started/mcp) · [`mcp-server/README.md`](mcp-server/README.md)
+3. **TryOn Studio** — Next.js UI (Agent, Connect, Image, VTON, Understand, Video, BG Remove) over MCP HTTP. Setup: [TryOn Studio](https://tryonlabs.github.io/opentryon/getting-started/tryon-studio)
+4. **Python** — `from tryon.api import ...` (and `tryon.cli.runner.invoke_model`)
 
 ## Install
 
@@ -105,10 +104,10 @@ Models marked local need `pip install opentryon[local]`. Full table and flags: [
 cd mcp-server
 pip install -r requirements.txt
 python server.py                                    # stdio (Claude Desktop / Cursor)
-python server.py --transport http --host 127.0.0.1 --port 8000
+python server.py --transport http --host 127.0.0.1 --port 8000   # TryOn Studio
 ```
 
-Tools are generated from `tryon/cli/registry.py` — the same registry as the CLI. See [`mcp-server/README.md`](mcp-server/README.md).
+Tools are generated from `tryon/cli/registry.py` — the same registry as the CLI. Guide: [MCP Server](https://tryonlabs.github.io/opentryon/getting-started/mcp) · full tool table: [`mcp-server/README.md`](mcp-server/README.md). Web UI: [TryOn Studio](https://tryonlabs.github.io/opentryon/getting-started/tryon-studio).
 
 ## Demos & notebooks
 
@@ -118,7 +117,7 @@ This package ships **Gradio** demos and **Jupyter** notebooks only:
 python run_demo.py --name extract_garment   # also: model_swap, outfit_generator
 ```
 
-Notebooks: [`notebooks/`](notebooks/). Web UI: [tryon-studio](https://github.com/tryonlabs/tryon-studio).
+Notebooks: [`notebooks/`](notebooks/). Web UI: [TryOn Studio](https://tryonlabs.github.io/opentryon/getting-started/tryon-studio).
 
 ## Layout
 
@@ -142,7 +141,8 @@ opentryon/
 |---|---|
 | Install & config | [Getting Started](https://tryonlabs.github.io/opentryon/docs/getting-started/installation) |
 | CLI | [CLI guide](https://tryonlabs.github.io/opentryon/docs/getting-started/cli) |
-| MCP | [MCP server](https://tryonlabs.github.io/opentryon/docs/getting-started/mcp) · [`mcp-server/README.md`](mcp-server/README.md) |
+| MCP | [MCP server](https://tryonlabs.github.io/opentryon/getting-started/mcp) · [`mcp-server/README.md`](mcp-server/README.md) |
+| TryOn Studio | [Setup and screens](https://tryonlabs.github.io/opentryon/getting-started/tryon-studio) · [`tryon-studio`](https://github.com/tryonlabs/tryon-studio) |
 | OpenAPI / Postman | [Swagger guide](https://tryonlabs.github.io/opentryon/docs/getting-started/openapi-swagger) · [`openapi/`](openapi/) · [`postman/`](postman/) |
 | Per-provider APIs | [API Reference](https://tryonlabs.github.io/opentryon/docs/api-reference/overview) |
 | Local / GPU models | [Local Models](https://tryonlabs.github.io/opentryon/docs/local-models/overview) |

--- a/docs/docs/agents/planner-agent.md
+++ b/docs/docs/agents/planner-agent.md
@@ -134,3 +134,9 @@ Returns `success`, `intent`, `agent`, `message`, `images_base64` / `video_base64
 ```bash
 conda run -n opentryon python tests/test_planner_agent.py
 ```
+
+## Related
+
+- [TryOn Studio](../getting-started/tryon-studio) — Agent chat is `planner_agent` over MCP HTTP
+- [MCP Server](../getting-started/mcp)
+- [`mcp-server/README.md`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/README.md)

--- a/docs/docs/community/contributing.md
+++ b/docs/docs/community/contributing.md
@@ -30,7 +30,7 @@ git checkout -b feature/your-feature-name
 - Write clean, documented code
 - Follow PEP 8 style guidelines
 - Add tests for new features
-- Update documentation
+- Update documentation (`docs/` Docusaurus site). New surfaces belong in Getting Started: [MCP Server](../getting-started/mcp), [TryOn Studio](../getting-started/tryon-studio).
 - For new cloud APIs or local models, follow
   [Model Integration Guidelines](../advanced/model-integration-guidelines.md)
   and the [new-model checklist](../advanced/new-model-checklist.md)

--- a/docs/docs/community/roadmap.md
+++ b/docs/docs/community/roadmap.md
@@ -25,7 +25,7 @@ Canonical file: [`ROADMAP.md`](https://github.com/tryonlabs/opentryon/blob/main/
 - Qwen-Image generate / edit / VTON (DashScope 3.0 + local Diffusers 2512 / Edit-2511)
 - **OpenAPI / Postman** media snapshots, docs, Gradio demos
 - Local extras (FLUX.2 Turbo, Kimi-VL, LLaVA-NeXT, BEN2, LTX-2.5, Wan 2.2, Qwen3.8, Qwen-Image)
-- Web UI in **tryon-studio** over [MCP](../getting-started/mcp)
+- Web UI in **[TryOn Studio](../getting-started/tryon-studio)** over **[MCP](../getting-started/mcp)**
 
 ## Next — Fashion ML Toolkit Core → v0.1.0
 

--- a/docs/docs/demos/fashion-prompt-builder.md
+++ b/docs/docs/demos/fashion-prompt-builder.md
@@ -1,5 +1,9 @@
 # Fashion Prompt Builder Demo
 
+:::note Not in the v1 Studio nav
+Fashion Prompt Builder is a use-case screen, not part of TryOn Studio v1. For the current playground see **[TryOn Studio](../getting-started/tryon-studio)**. The notes below describe the older Next.js demo.
+:::
+
 A modern, responsive web application for generating prompts for fashion model generation. Built with Next.js 14, Tailwind CSS, and TypeScript.
 
 ## Overview

--- a/docs/docs/demos/overview.md
+++ b/docs/docs/demos/overview.md
@@ -1,41 +1,38 @@
 # Demos
 
-OpenTryOn includes interactive demos for easy experimentation and testing.
+OpenTryOn includes in-repo **Gradio** demos for quick experiments. The current web playground is **TryOn Studio**, which talks to OpenTryOn over MCP — it is not in this repository.
 
-## Available Demos
+## TryOn Studio (recommended UI)
 
-### Virtual Try-On Demo (Full-Stack Web App) ⭐ NEW
+[TryOn Studio](https://github.com/tryonlabs/tryon-studio) is a Next.js MCP client: Agent chat, Connect, Image generate/edit, VTON, Understand, Video, and background removal.
 
-A modern, production-ready virtual try-on web application with FastAPI backend and Next.js frontend.
+**Quick start** (two processes):
 
-**Features**:
-- Support for 4 AI models (Nano Banana, Nano Banana Pro, FLUX 2 Pro, FLUX 2 Flex)
-- Multi-image upload with drag & drop
-- Real-time credit estimation
-- Modern, responsive UI
-- RESTful API
+1. Start the MCP server from this repo:
 
-**Quick Start**:
-
-1. Start the backend:
 ```bash
-python api_server.py
+cd mcp-server
+python server.py --transport http --host 127.0.0.1 --port 8000
 ```
 
-2. In a new terminal, start the frontend:
+2. In another terminal, start Studio:
+
 ```bash
-cd demo/virtual-tryon
+cd tryon-studio
+cp .env.local.example .env.local
 npm install
 npm run dev
 ```
 
-3. Open `http://localhost:3000` in your browser
+Open [http://localhost:3000/connect](http://localhost:3000/connect) first.
 
-**[Read Full Documentation →](./virtual-tryon)**
+**[Full setup and screen tour →](../getting-started/tryon-studio)** · **[MCP Server →](../getting-started/mcp)**
 
 ---
 
-### Extract Garment Demo (Gradio)
+## Gradio demos (in this repo)
+
+### Extract Garment
 
 Interactive Gradio demo for garment extraction.
 
@@ -45,7 +42,7 @@ python run_demo.py --name extract_garment
 
 **[Read More →](./extract-garment)**
 
-### Model Swap Demo (Gradio)
+### Model Swap
 
 Interactive Gradio demo for swapping garments between models.
 
@@ -55,7 +52,7 @@ python run_demo.py --name model_swap
 
 **[Read More →](./model-swap)**
 
-### Outfit Generator Demo (Gradio)
+### Outfit Generator
 
 Interactive Gradio demo for generating outfits from text prompts.
 
@@ -65,29 +62,14 @@ python run_demo.py --name outfit_generator
 
 **[Read More →](./outfit-generator)**
 
-### Fashion Prompt Builder Demo (Next.js)
-
-A modern Next.js web application for generating prompts for fashion model generation.
-
-```bash
-cd demo/fashion-prompt-builder
-npm install
-npm run dev
-```
-
-Open `http://localhost:3000` to access the prompt builder interface.
-
-**[Read Full Documentation →](./fashion-prompt-builder)**
-
 ---
 
-## Demo Comparison
+## Demo comparison
 
-| Demo | Type | Tech Stack | Use Case |
-|------|------|------------|----------|
-| **Virtual Try-On** | Full-stack Web App | Next.js + FastAPI | Production-ready virtual try-on with multiple AI models |
-| **Fashion Prompt Builder** | Web App | Next.js + TypeScript | Generate high-quality prompts for fashion AI models |
-| **Extract Garment** | Gradio | Python + Gradio | Quick garment extraction testing |
-| **Model Swap** | Gradio | Python + Gradio | Garment swapping experiments |
-| **Outfit Generator** | Gradio | Python + Gradio | Text-to-outfit generation |
+| Demo | Type | Where | Use case |
+|------|------|-------|----------|
+| **TryOn Studio** | Next.js MCP client | [tryon-studio](https://github.com/tryonlabs/tryon-studio) | Agent + all registry capabilities |
+| **Extract Garment** | Gradio | `demo/extract_garment` | Quick garment extraction |
+| **Model Swap** | Gradio | `demo/model_swap` | Garment swapping experiments |
+| **Outfit Generator** | Gradio | `demo/outfit_generator` | Text-to-outfit generation |
 

--- a/docs/docs/demos/virtual-tryon.md
+++ b/docs/docs/demos/virtual-tryon.md
@@ -1,6 +1,10 @@
 # Virtual Try-On Demo
 
-A modern, full-stack virtual try-on web application featuring a Next.js frontend and FastAPI backend. Generate realistic virtual try-on images using state-of-the-art AI models.
+:::note Current playground
+The Next.js + FastAPI demo that used to live in `demo/virtual-tryon/` is no longer in this repository. Use **[TryOn Studio](../getting-started/tryon-studio)** over the **[MCP server](../getting-started/mcp)** for the current UI (Agent, Connect, VTON, Image, Understand, Video, BG Remove).
+:::
+
+A historical full-stack virtual try-on web application featuring a Next.js frontend and FastAPI backend. The notes below describe that older demo.
 
 ## Overview
 

--- a/docs/docs/getting-started/cli.md
+++ b/docs/docs/getting-started/cli.md
@@ -205,6 +205,7 @@ stack trace:
 ## See Also
 
 - [MCP Server](mcp)
+- [TryOn Studio](tryon-studio)
 - [OpenAPI & Postman](openapi-swagger)
 - [Kimi K2.6 / K2.7 Code / K3 understanding](../api-reference/kimi.md)
 - [Kimi-VL open-weight local model](../local-models/kimi-vl.md)

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Learn how to configure OpenTryOn for your specific needs. OpenTryOn supports three main categories: **Preprocessing**, **API Integrations**, and **Datasets**.
+Learn how to configure OpenTryOn for your specific needs. The same `opentryon/.env` file is read by the **CLI**, the **[MCP server](mcp)**, and **[TryOn Studio](tryon-studio)** Connect (Studio never stores keys itself).
 
 ## Environment Variables
 
@@ -83,7 +83,7 @@ HF_DATASETS_CACHE=path/to/cache
 
 ### Planner / Studio chat (optional — only if you use `planner_agent`)
 
-The cheap intent model is separate from image/VTON/video keys. See [Planner Agent](../agents/planner-agent.md).
+The cheap intent model is separate from image/VTON/video keys. Studio Agent chat calls MCP `planner_agent`; set these on the MCP host and restart the server. See [Planner Agent](../agents/planner-agent.md) and [TryOn Studio](tryon-studio).
 
 ```env
 OPENTRYON_AGENT_LLM_PROVIDER=openai

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -87,6 +87,13 @@ After installation, verify that OpenTryOn is correctly installed:
 python -c "import tryon; print('OpenTryOn', tryon.__version__, 'installed successfully')"
 ```
 
+## MCP server and TryOn Studio
+
+The same install is what the MCP server and Studio talk to.
+
+- **MCP:** `cd mcp-server && pip install -r requirements.txt && python server.py` (stdio) or `python server.py --transport http --host 127.0.0.1 --port 8000` (Studio). Guide: [MCP Server](mcp). Full tool table: [`mcp-server/README.md`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/README.md).
+- **Studio:** clone [tryon-studio](https://github.com/tryonlabs/tryon-studio), point `OPENTRYON_MCP_URL` at that HTTP endpoint, `npm run dev`. Guide: [TryOn Studio](tryon-studio).
+
 ## Configuration
 
 ### Environment Variables
@@ -213,11 +220,14 @@ If you encounter issues:
 
 Once installed:
 
-1. **[Quick Start Guide](quickstart.md)**: Get started with API integrations, datasets, and preprocessing
-2. **[Configuration Guide](configuration.md)**: Set up environment variables and API keys
-3. **[API Reference](../api-reference/overview)**: Explore cloud-based virtual try-on and image generation APIs
-4. **[Datasets Module](../datasets/overview)**: Learn how to load and work with fashion datasets
-5. **[Preprocessing](../preprocessing/overview)**: Process garments, models, and images for virtual try-on
+1. **[Quick Start Guide](quickstart.md)**: First CLI / Python runs
+2. **[MCP Server](mcp)**: Expose every registry model as tools for Cursor, Claude, or Studio
+3. **[TryOn Studio](tryon-studio)**: Next.js UI — Agent chat, Connect, Image, VTON, Understand, Video, BG Remove
+4. **[Configuration Guide](configuration.md)**: Set up environment variables and API keys
+5. **[Unified CLI](cli)**: `opentryon <service> --model <model>`
+6. **[API Reference](../api-reference/overview)**: Cloud adapters
+7. **[Datasets Module](../datasets/overview)**: Fashion-MNIST, VITON-HD, Subjects200K
+8. **[Preprocessing](../preprocessing/overview)**: Garments, models, and images for virtual try-on
 
 ### Key Features to Explore
 

--- a/docs/docs/getting-started/mcp.md
+++ b/docs/docs/getting-started/mcp.md
@@ -1,13 +1,14 @@
 ---
 sidebar_position: 5
 title: MCP Server
-description: Expose every OpenTryOn registry model as Model Context Protocol tools for Cursor, Claude, and tryon-studio
+description: Install and run the OpenTryOn Model Context Protocol server — registry tools for Cursor, Claude, and TryOn Studio
 keywords:
   - MCP
   - Model Context Protocol
   - FastMCP
   - Cursor
   - Claude
+  - TryOn Studio
   - opentryon
 ---
 
@@ -15,13 +16,125 @@ keywords:
 
 OpenTryOn ships a [Model Context Protocol](https://modelcontextprotocol.io) server under `mcp-server/`. Every model in `tryon.cli.registry` becomes an MCP tool automatically — the same surface as the `opentryon` CLI, via `tryon.cli.runner.invoke_model()`.
 
-**Current release:** works with OpenTryOn **v0.0.4+** (`pip install -U opentryon`).
+**Current release:** OpenTryOn **v0.0.4+** (`pip install -U opentryon`).
+
+This page is the Docusaurus guide for the server. Keep it next to:
+
+- **In-repo README (full tool table):** [`mcp-server/README.md`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/README.md)
+- **TryOn Studio (the web MCP client):** [TryOn Studio](tryon-studio)
 
 ## Why it matters
 
-- Agents in **Cursor**, **Claude Desktop**, or **tryon-studio** can call try-on, generate, edit, video, understand, and bg-remove tools directly. Studio **chat** goes through `planner_agent`: it classifies intent, then runs a **filtered slice** of those same registry tools via `invoke_model`. Capability screens skip the planner and call the model tools themselves.
-- New registry models appear as tools with **zero hand-written MCP wrappers**
-- CLI and MCP cannot drift — one runner, one registry
+- Agents in **Cursor**, **Claude Desktop**, or **TryOn Studio** call try-on, generate, edit, video, understand, and bg-remove tools directly.
+- Studio **chat** goes through `planner_agent`: it classifies intent, then runs a **filtered slice** of those same registry tools via `invoke_model`. Capability screens skip the planner and call the model tools themselves.
+- New registry models appear as tools with **zero hand-written MCP wrappers**.
+- CLI and MCP cannot drift — one runner, one registry.
+
+## Install
+
+```bash
+cd opentryon
+pip install -e .              # core (API-backed) models
+# optional GPU extras (leffa, catvton, kimi-vl, qwen3.8, ben2, …):
+pip install -e ".[local]"
+
+cd mcp-server
+pip install -r requirements.txt
+```
+
+Copy repo-root `env.template` to `.env` and fill the keys you plan to use. The server and every adapter read that same file.
+
+## Run
+
+```bash
+# stdio — what Claude Desktop / Cursor expect
+python server.py
+
+# streamable-HTTP — required by TryOn Studio
+python server.py --transport http --host 127.0.0.1 --port 8000
+```
+
+On startup the server prints a configuration report to stderr (which keys are set, which models are ready) — the same text `opentryon_status` returns at runtime.
+
+| Transport | Typical client | Endpoint |
+|---|---|---|
+| stdio (default) | Cursor, Claude Desktop | process stdin/stdout |
+| HTTP | [TryOn Studio](tryon-studio), FastMCP `Client` over the network | `http://127.0.0.1:8000/mcp` |
+
+Studio’s only URL is `OPENTRYON_MCP_URL=http://127.0.0.1:8000/mcp`. Remote MCP hosts are out of scope for Studio.
+
+## Clients
+
+### TryOn Studio
+
+HTTP MCP plus a Next.js UI (Agent, Connect, Image, VTON, Understand, Video, BG Remove). Full setup: [TryOn Studio](tryon-studio).
+
+### Cursor
+
+Add to `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global). Example: [`mcp-server/examples/cursor_mcp_config.json`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/examples/cursor_mcp_config.json).
+
+```json
+{
+  "mcpServers": {
+    "opentryon": {
+      "command": "python",
+      "args": ["/absolute/path/to/opentryon/mcp-server/server.py"]
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`. Example: [`mcp-server/examples/claude_desktop_config.json`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/examples/claude_desktop_config.json).
+
+```json
+{
+  "mcpServers": {
+    "opentryon": {
+      "command": "python",
+      "args": ["/absolute/path/to/opentryon/mcp-server/server.py"]
+    }
+  }
+}
+```
+
+### Python (FastMCP client)
+
+See [`mcp-server/examples/example_usage.py`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/examples/example_usage.py).
+
+```python
+import asyncio
+from fastmcp import Client
+
+async def main():
+    async with Client("server.py") as client:
+        result = await client.call_tool("vton_flux_vto", {
+            "person": "model.jpg",
+            "garment": "garment.jpg",
+            "dry_run": True,
+        })
+        print(result.data)
+
+asyncio.run(main())
+```
+
+## Discovery, keys, and the planner
+
+Always available, independent of which models you configured:
+
+| Tool | Role |
+|---|---|
+| `list_opentryon_tools` | Services, models, MCP tool names, env readiness |
+| `opentryon_status` | Same human-readable report printed on startup |
+| `list_api_keys` / `set_api_keys` | Inspect or upsert host `.env` keys (never returns secret values). Studio Connect uses these |
+| `planner_agent` | Studio Agent chat entrypoint. Cheap LLM classifies intent, then `invoke_model` on a filtered slice. [Planner Agent](../agents/planner-agent) |
+
+Every generated model tool also accepts `dry_run` and `output_dir`, matching the CLI.
+
+## Selected tools
+
+The tables below highlight newer families. The complete generated list lives in [`mcp-server/README.md`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/README.md) and grows with `tryon/cli/registry.py`.
 
 ## Understand tools (including Qwen3.8 and Hy4)
 
@@ -151,38 +264,14 @@ Same `PRUNA_API_KEY` as the rest of the Pruna family. **Not** Ideogram 4.0 (`gen
 
 See [P-Image-Ideogram](../api-reference/p-image-ideogram.md).
 
-## Quick start
-
-```bash
-cd mcp-server
-pip install -r requirements.txt   # includes fastmcp
-cp ../env.template ../.env        # fill API keys you need
-python server.py                  # stdio (default for most MCP clients)
-# or:
-python server.py --transport http --host 127.0.0.1 --port 8000
-```
-
-Discovery tools:
-
-- `list_opentryon_tools` — list services / models / tool names / env readiness
-- `opentryon_status` — configuration status report
-- `list_api_keys` / `set_api_keys` — inspect or upsert host `.env` keys (never returns secret values). TryOn Studio Connect uses these.
-
-Every generated tool accepts `dry_run` and `output_dir`, matching the CLI.
-
-## Client config
-
-See example configs in the repo:
-
-- [`mcp-server/examples/cursor_mcp_config.json`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/examples/cursor_mcp_config.json)
-- [`mcp-server/examples/claude_desktop_config.json`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/examples/claude_desktop_config.json)
-
-Full tool tables and architecture notes: [`mcp-server/README.md`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/README.md).
-
 ## Related
 
+- [TryOn Studio](tryon-studio) — Next.js MCP client (Agent, Connect, capability screens)
+- [`mcp-server/README.md`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/README.md) — architecture notes and full generated tool table
 - [Planner Agent](../agents/planner-agent)
 - [Unified CLI](cli)
+- [Configuration](configuration)
+- [Adding a new model](../advanced/new-model-checklist)
 - [Qwen3.8-Max understanding](../api-reference/qwen3.8)
 - [Hy4 preview TokenHub](../api-reference/hy4)
 - [Hy4 local vLLM/SGLang](../local-models/hy4)
@@ -193,5 +282,3 @@ Full tool tables and architecture notes: [`mcp-server/README.md`](https://github
 - [MiniMax H3 local](../local-models/minimax-h3)
 - [Muse Image](../api-reference/muse-image)
 - [P-Image-Ideogram](../api-reference/p-image-ideogram)
-- [Adding a new model](../advanced/new-model-checklist)
-- [Configuration](configuration)

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-Get started with OpenTryOn in minutes! This guide will walk you through the key features: **API integrations**, **datasets**, and **preprocessing**.
+Get started with OpenTryOn in minutes. The same registry powers the **CLI**, the **MCP server**, and **TryOn Studio**.
 
 ## Prerequisites
 
@@ -8,13 +8,24 @@ Get started with OpenTryOn in minutes! This guide will walk you through the key 
 - Environment variables configured (see [Configuration Guide](configuration.md))
 - API keys for cloud services (optional, for API integrations)
 
-## What You Can Do
+## Four ways to run a model
 
-OpenTryOn provides three main capabilities:
+| Surface | When to use it | Guide |
+|---|---|---|
+| **CLI** | Scripts, `--dry-run`, one-off jobs | [Unified CLI](cli) |
+| **MCP server** | Cursor, Claude, or any MCP client | [MCP Server](mcp) · [`mcp-server/README.md`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/README.md) |
+| **TryOn Studio** | Browser UI: Agent, Connect, capability screens | [TryOn Studio](tryon-studio) |
+| **Python** | `tryon.api` adapters in your own code | examples below |
 
-1. **🔌 API Integrations**: Use cloud-based virtual try-on and image generation APIs
-2. **📊 Datasets**: Load and work with fashion datasets (Fashion-MNIST, VITON-HD, Subjects200K)
-3. **🛠️ Preprocessing**: Process garments, models, and images for virtual try-on
+Studio needs the MCP server on **HTTP** (`python server.py --transport http --host 127.0.0.1 --port 8000`), then `npm run dev` in [tryon-studio](https://github.com/tryonlabs/tryon-studio). Open `/connect` first.
+
+## What else you can do
+
+OpenTryOn also includes:
+
+1. **API integrations**: cloud virtual try-on and image generation
+2. **Datasets**: Fashion-MNIST, VITON-HD, Subjects200K
+3. **Preprocessing**: garments, models, and images for virtual try-on
 
 ## Quick Examples
 
@@ -448,6 +459,8 @@ python run_demo.py --name outfit_generator
 
 ### Additional Resources
 
+- [MCP Server](mcp): Cursor, Claude, and Studio tool surface
+- [TryOn Studio](tryon-studio): Agent chat, Connect, and capability screens
 - [Examples](../examples/basic-usage): Real-world usage examples
 - [TryOnDiffusion](../tryondiffusion/overview): Advanced diffusion-based virtual try-on
 - [Configuration Guide](configuration): Environment setup and API keys

--- a/docs/docs/getting-started/tryon-studio.md
+++ b/docs/docs/getting-started/tryon-studio.md
@@ -1,0 +1,136 @@
+---
+sidebar_position: 6
+title: TryOn Studio
+description: Set up TryOn Studio — the Next.js MCP client for OpenTryOn Agent chat, Connect, and capability screens
+keywords:
+  - TryOn Studio
+  - tryon-studio
+  - MCP client
+  - virtual try-on UI
+  - planner agent
+  - Connect
+---
+
+# TryOn Studio
+
+[TryOn Studio](https://github.com/tryonlabs/tryon-studio) is the Next.js playground for OpenTryOn. It is an **MCP client only**: it never imports OpenTryOn Python, never reads the OpenTryOn filesystem, and never stores provider API keys. Every model, adapter, and agent lives in this repo (`tryon/cli/registry.py` + `mcp-server/`). Studio talks to that stack over MCP HTTP.
+
+This page is the setup and product tour. The protocol, tools, and server process are documented in [MCP Server](mcp).
+
+## Architecture
+
+```
+┌────────────────────────────┐        MCP over HTTP        ┌──────────────────────────────┐
+│  tryon-studio              │ ───────────────────────────▶ │  opentryon/mcp-server         │
+│  Next.js (App Router)      │                              │  FastMCP, streamable-HTTP     │
+│  - Connect + capabilities  │ ◀─────────────────────────── │  registry models + discovery  │
+│  - Agent chat              │   JSON + images_base64 /     │  + planner_agent              │
+│  - Route handlers = MCP    │   video_base64               │                                │
+│    client                  │                              │                                │
+└────────────────────────────┘                              └──────────────────────────────┘
+```
+
+- **OpenTryOn owns adapters and agents.** New registry models appear in Connect and the capability pickers after an MCP restart.
+- **Studio’s only env var** is `OPENTRYON_MCP_URL` (default `http://127.0.0.1:8000/mcp`). Planner LLM keys, image keys, and VTON keys live in `opentryon/.env`.
+- **Media on the wire** is `images_base64` / `video_base64`, not host file paths.
+- Remote MCP hosts are out of scope in this phase — keep the URL on localhost.
+
+## What is in Studio
+
+The v1 nav is **Agent · Capabilities · Connect**. Capability screens share one shell: model + params rail, canvas, and an inspector (request / response / MCP / CLI / Python / auth). Forms default to **dry-run** so you can preview a call without spending API credits.
+
+| Screen | Route | What it does |
+|---|---|---|
+| **Connect** | `/connect` | Ping MCP, list live tools, show which host keys are loaded, paste keys as a passthrough into `opentryon/.env` |
+| **Agent** | `/` and `/c/[sessionId]` | Chat. Studio calls MCP `planner_agent` only — it does not run its own tool loop |
+| **Image** | `/image?mode=generate` or `?mode=edit` | Text-to-image or instruction edit. `/generate` and `/edit` redirect here |
+| **VTON** | `/vton` | Person + garment virtual try-on |
+| **Understand** | `/understand` | Caption / Q&A on an image, a video URL, or a text LLM such as Hy4 |
+| **Video** | `/video` | Text-to-video or first-frame-to-video |
+| **BG Remove** | `/bg-remove` | Cut the subject out of a photo |
+
+Use-case screens (Fashion Prompt Builder, styling, …) may still have routes for later work; they are **not** in the v1 sidebar.
+
+### Agent chat
+
+Chat is a super-agent over the live registry, not a launcher that only deep-links to capability pages.
+
+- OpenTryOn classifies intent with a cheap planner LLM, then runs a **filtered slice** of the same tools the capability screens use (`invoke_model`).
+- If you name a model (`wan-3.0`, `hy4-preview`, `leffa`, …) that registry id is exclusive for the turn.
+- Otherwise the planner uses the capability default: VTON `kling-ai`, generate/edit `nano-banana-pro`, understand `kimi-k2.6`, video `sora`, bg-remove `ben2`.
+- This turn’s first attached image is `person_image` / `image`; the second is `garment_image`. Follow-ups reuse the latest prior user photos.
+- Returned `images_base64` / `video_base64` persist as chat attachments.
+- Questions such as “what is Hy4 preview?” are answered from the live registry catalog (label + notes), not by guessing.
+
+If `planner_agent` is missing, update OpenTryOn and restart MCP. Full behavior: [Planner Agent](../agents/planner-agent).
+
+### Connect
+
+Connect is the status desk, not a second key store.
+
+- `list_opentryon_tools` / `opentryon_status` show what the MCP host loaded.
+- `list_api_keys` / `set_api_keys` write `opentryon/.env` on the MCP machine (mode `0600`). Studio does **not** keep secrets in `studio.db`, cookies, or `localStorage`.
+- Local GPU extras (`leffa`, `catvton`, `hy4-preview-local`, …) show as local/self-hosted — they do not need a Connect key. Hy4 TokenHub uses `TOKENHUB_API_KEY`; Vertex Virtual Try-On uses `GOOGLE_CLOUD_PROJECT` (ADC stays on the MCP host).
+
+## Setup
+
+You need **two processes**: the OpenTryOn MCP server (HTTP) and Studio.
+
+### 1. OpenTryOn MCP (this repo)
+
+```bash
+git clone https://github.com/tryonlabs/opentryon.git
+cd opentryon
+pip install -e .                 # or -e ".[local]" for GPU-backed models
+cp env.template .env             # image / VTON / planner LLM keys
+cd mcp-server
+pip install -r requirements.txt
+python server.py --transport http --host 127.0.0.1 --port 8000
+```
+
+Studio requires **streamable-HTTP**, not stdio. Cursor / Claude Desktop can keep using stdio; that is a separate client. See [MCP Server](mcp) for transports, discovery tools, and Cursor/Claude config.
+
+For Agent chat, also set in `opentryon/.env`:
+
+```bash
+OPENTRYON_AGENT_LLM_PROVIDER=openai   # openai | anthropic | google
+OPENTRYON_PLANNER_LLM_MODEL=gpt-4o-mini
+OPENAI_API_KEY=...                    # matching provider key
+```
+
+Restart MCP after changing planner settings or adding a registry model.
+
+### 2. Studio
+
+Node.js 20+ is enough. Clone [tryon-studio](https://github.com/tryonlabs/tryon-studio) next to OpenTryOn (or anywhere — they only share HTTP).
+
+```bash
+git clone https://github.com/tryonlabs/tryon-studio.git
+cd tryon-studio
+cp .env.local.example .env.local
+npm install
+npm run dev
+```
+
+`.env.local` (the only Studio config):
+
+```bash
+OPENTRYON_MCP_URL=http://127.0.0.1:8000/mcp
+```
+
+Open [http://localhost:3000/connect](http://localhost:3000/connect) first. Confirm MCP is up, scan the live tool list, then use Agent or a capability screen.
+
+## Adding a model
+
+Add it in OpenTryOn (`tryon/cli/registry.py`) and **restart MCP**. Connect and the capability pickers load `list_opentryon_tools` plus each tool’s JSON Schema — no Studio code change.
+
+Do not add a parallel HTTP client in tryon-studio. Checklist: [New model checklist](../advanced/new-model-checklist).
+
+## Related
+
+- [MCP Server](mcp) — install, run, discovery tools, Cursor / Claude
+- [`mcp-server/README.md`](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/README.md) — full generated tool table
+- [Planner Agent](../agents/planner-agent)
+- [Unified CLI](cli)
+- [Configuration](configuration)
+- [tryon-studio on GitHub](https://github.com/tryonlabs/tryon-studio)

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -42,6 +42,8 @@ keywords:
   - opentryon CLI
   - MCP
   - Model Context Protocol
+  - TryOn Studio
+  - FastMCP
   - Pruna
   - Seedance
   - Seedream
@@ -59,11 +61,12 @@ OpenTryOn is an open-source AI toolkit for fashion technology and virtual try-on
 
 ## 🎯 What is OpenTryOn?
 
-OpenTryOn gives you three ways to run fashion AI models:
+OpenTryOn gives you four ways to run fashion AI models:
 
 1. **CLI** — `opentryon <service> --model <model> …`
-2. **MCP server** — tools for Cursor, Claude, and [tryon-studio](getting-started/mcp)
-3. **Python APIs** — `tryon.api` adapters + `invoke_model()`
+2. **MCP server** — tools for Cursor, Claude, and any MCP client ([guide](getting-started/mcp), [in-repo README](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/README.md))
+3. **TryOn Studio** — Next.js playground that talks to the MCP server ([setup and screens](getting-started/tryon-studio))
+4. **Python APIs** — `tryon.api` adapters + `invoke_model()`
 
 Plus preprocessing, datasets, Gradio demos, and TryOnDiffusion research code.
 
@@ -71,7 +74,8 @@ Plus preprocessing, datasets, Gradio demos, and TryOnDiffusion research code.
 
 ### Developer surfaces
 - Unified **registry-driven CLI** with `--dry-run`
-- **FastMCP** server — every registry model is a tool
+- **FastMCP** server — every registry model is a tool ([MCP Server](getting-started/mcp))
+- **TryOn Studio** — Agent chat, Connect, and capability screens over MCP HTTP ([setup](getting-started/tryon-studio))
 - **OpenAPI / Swagger** + **Postman** snapshots for upstream media APIs ([guide](getting-started/openapi-swagger))
 - **Model integration guidelines** for Path A (API) vs Path B (local)
 
@@ -87,8 +91,8 @@ Veo, Sora, Luma Ray 2 + **Ray 3.2**, **Seedance 2.5**, **Kling 3.0 / Omni / Turb
 ### Understanding & other
 **Kimi K2.6 / K2.7 Code / K3** (API), Kimi-VL & LLaVA-NeXT (local), **Qwen3.8-Max** (API) + **Qwen3.8-27B** (local), **Hy4 preview** (TokenHub + local vLLM/SGLang), BEN2 bg-remove, fashion datasets, garment/pose preprocessing.
 
-### Interactive demos
-Gradio apps in-repo; the Next.js playground/studio UI lives in **tryon-studio** and talks to OpenTryOn over MCP.
+### Interactive playground
+**[TryOn Studio](getting-started/tryon-studio)** is the Next.js UI: Agent chat (`planner_agent`), Connect (MCP status + key passthrough), and capability screens (Image, VTON, Understand, Video, BG Remove). In-repo **Gradio** apps remain for extract-garment / model-swap / outfit-generator.
 
 ## 📚 What You'll Learn
 
@@ -98,7 +102,8 @@ In this documentation, you'll find:
 - **[Quick Start](getting-started/quickstart)**: First successful runs
 - **[Configuration](getting-started/configuration)**: API keys and `.env`
 - **[Unified CLI](getting-started/cli)**: Service → model → params
-- **[MCP Server](getting-started/mcp)**: Agent / IDE tool surface
+- **[MCP Server](getting-started/mcp)**: Agent / IDE tool surface, plus the [`mcp-server` README](https://github.com/tryonlabs/opentryon/blob/main/mcp-server/README.md)
+- **[TryOn Studio](getting-started/tryon-studio)**: Web UI setup, Agent, Connect, and capability screens
 - **[OpenAPI & Postman](getting-started/openapi-swagger)**: Swagger for upstream media APIs
 - **[Fashion ML Engineer Path](getting-started/fashion-ml)**: Train → eval → invoke → workflow (toward v0.1.0)
 - **[Datasets Module](datasets/overview)**: Fashion-MNIST, VITON-HD, Subjects200K

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -220,6 +220,18 @@ const config: Config = {
           label: 'Docs',
         },
         {
+          type: 'doc',
+          docId: 'getting-started/mcp',
+          position: 'left',
+          label: 'MCP',
+        },
+        {
+          type: 'doc',
+          docId: 'getting-started/tryon-studio',
+          position: 'left',
+          label: 'Studio',
+        },
+        {
           type: 'html',
           position: 'right',
           value: '<a href="https://github.com/tryonlabs/opentryon" target="_blank" rel="noopener noreferrer" class="navbar__item navbar__link navbar__link-with-icon" aria-label="GitHub"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg><span>GitHub</span></a>',
@@ -240,6 +252,14 @@ const config: Config = {
             {
               label: 'Getting Started',
               to: '/getting-started/installation',
+            },
+            {
+              label: 'MCP Server',
+              to: '/getting-started/mcp',
+            },
+            {
+              label: 'TryOn Studio',
+              to: '/getting-started/tryon-studio',
             },
             {
               label: 'API Reference',
@@ -325,6 +345,14 @@ const config: Config = {
           {
             from: ['/getting-started'],
             to: '/getting-started/installation',
+          },
+          {
+            from: ['/studio', '/tryon-studio'],
+            to: '/getting-started/tryon-studio',
+          },
+          {
+            from: ['/mcp'],
+            to: '/getting-started/mcp',
           },
           {
             from: ['/tryondiffusion'],

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -12,6 +12,7 @@ const sidebars: SidebarsConfig = {
         'getting-started/configuration',
         'getting-started/cli',
         'getting-started/mcp',
+        'getting-started/tryon-studio',
         'getting-started/openapi-swagger',
         'getting-started/fashion-ml',
       ],

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,13 @@
 
 An [MCP](https://modelcontextprotocol.io) (Model Context Protocol) server that exposes every model in the [`opentryon`](../README.md) toolkit -- virtual try-on, image/video generation & editing, multimodal image & video understanding, and background removal -- as tools an LLM agent (Claude, Cursor, ChatGPT, or any MCP client) can call directly.
 
-Requires **OpenTryOn v0.0.4+** (`pip install -U opentryon`). Docs: [MCP Server guide](https://tryonlabs.github.io/opentryon/docs/getting-started/mcp).
+Requires **OpenTryOn v0.0.4+** (`pip install -U opentryon`).
+
+**Documentation:**
+
+- [MCP Server guide](https://tryonlabs.github.io/opentryon/getting-started/mcp) — install, transports, Cursor / Claude / Studio
+- [TryOn Studio](https://tryonlabs.github.io/opentryon/getting-started/tryon-studio) — Next.js MCP client (Agent, Connect, capability screens)
+- This README — architecture notes and the full generated tool table
 
 Built on [FastMCP](https://gofastmcp.com) 3.x, the actively-maintained, high-level Python framework for MCP servers (FastMCP 1.0 was folded into the official MCP Python SDK in 2024; this server uses the standalone FastMCP 2/3 project, which adds streamable-HTTP transport, better auth, and much less boilerplate).
 
@@ -36,9 +42,11 @@ Copy `env.template` (repo root) to `.env` and fill in whichever API keys you pla
 # stdio transport (what Claude Desktop / Cursor / most MCP clients expect)
 python server.py
 
-# streamable-HTTP transport, for remote/network clients
-python server.py --transport http --host 0.0.0.0 --port 8000
+# streamable-HTTP transport, for TryOn Studio and network clients
+python server.py --transport http --host 127.0.0.1 --port 8000
 ```
+
+TryOn Studio needs the HTTP transport (`OPENTRYON_MCP_URL=http://127.0.0.1:8000/mcp`). Setup: [TryOn Studio](https://tryonlabs.github.io/opentryon/getting-started/tryon-studio).
 
 On startup the server prints a configuration status report to stderr (which API keys are set, which models are ready) -- the same information the `opentryon_status` tool returns at runtime.
 


### PR DESCRIPTION
## Description

The docs site now treats the MCP server and TryOn Studio as first-class getting-started surfaces: a Studio setup/screens page, a fuller MCP install and client guide, and intro/install/quickstart/demos links. GitHub Pages continues to publish from the `gh-pages` branch.

## Related Issue

Fixes #98

## Testing

Docusaurus `npm run build` in `docs/` succeeded (`onBrokenLinks: throw`). The built site was published with `npx gh-pages -d build`.

## Additional Notes

No GitHub Actions docs workflow; Pages is the `gh-pages` branch. Uncommitted `docs/package-lock.json` npm noise is not in this PR.

Made with [Cursor](https://cursor.com)